### PR TITLE
term and date checking for schedule upload and attendance

### DIFF
--- a/frontend/app/src/main/java/com/example/get2class/UploadScheduleActivity.kt
+++ b/frontend/app/src/main/java/com/example/get2class/UploadScheduleActivity.kt
@@ -21,6 +21,7 @@ import org.json.JSONException
 import org.json.JSONObject
 import java.io.IOException
 import java.time.LocalDate
+import java.time.Month
 import java.time.format.DateTimeFormatter
 
 @Parcelize
@@ -111,14 +112,15 @@ class UploadScheduleActivity : AppCompatActivity() {
             contentResolver.openInputStream(uri)?.use { inputStream ->
                 val workbook = WorkbookFactory.create(inputStream)
                 val sheet = workbook.getSheetAt(0)
-
                 var rowNum = 0
                 for (row in sheet) {
                     // Ignore classes that aren't in person
                     if (row.getCell(MODE).toString() != "In Person Learning") {
+                        Log.e(TAG, "Class rejected with reason: Not in person")
                         rowNum++
                         continue
                     }
+
 
                     if (rowNum > 2) {
                         // Create the full name value
@@ -136,6 +138,13 @@ class UploadScheduleActivity : AppCompatActivity() {
                         Log.d(TAG, "Start Date: $startDate")
                         val endDate = LocalDate.parse(row.getCell(END_DATE).toString(), dateFormatter)
                         Log.d(TAG, "End Date: $endDate")
+
+                        // Skip adding any classes that have the wrong start and end dates for this term
+                        if (!checkTerm(startDate, endDate)) {
+                            Log.e(TAG, "Class rejected with reason: Not this term")
+                            rowNum++
+                            continue
+                        }
 
                         // Get the meeting pattern
                         val pattern = row.getCell(PATTERN).toString()
@@ -244,4 +253,16 @@ class UploadScheduleActivity : AppCompatActivity() {
             }
         })
     }
+
+    // Check that the class is in the right term
+    private fun checkTerm(startDate: LocalDate, endDate: LocalDate): Boolean {
+        val term = intent.getStringExtra("term")
+        return when (term) {
+            "Fall" -> startDate.month == Month.SEPTEMBER && endDate.month == Month.DECEMBER
+            "Winter" -> startDate.month == Month.JANUARY && endDate.month == Month.APRIL
+            else -> startDate.month in listOf(Month.MAY, Month.JULY) &&
+                    endDate.month in listOf(Month.JUNE, Month.AUGUST)
+        }
+    }
+
 }


### PR DESCRIPTION
Working:
- Checking into class updates the karma on the BE. This can be seen on the karma page. It also marks the class as attended and if you try to check in again it rejects you.
- Users can only upload classes that are in the correct term (ie if they try to upload a summer schedule to their winter all the classes will be rejected)
- You can no longer check attendance for classes you don't have this term (by comparing to the current date)